### PR TITLE
Enable creating entries from template on all sites, not just the default

### DIFF
--- a/src/controllers/CpController.php
+++ b/src/controllers/CpController.php
@@ -236,8 +236,21 @@ class CpController extends Controller
         $elementsService = Craft::$app->getElements();
         $elementId = $request->getRequiredBodyParam('elementId');
         $contentTemplateId = $request->getRequiredBodyParam('contentTemplateId');
+        $siteHandle = $request->getQueryParam('site', null);
 
-        $element = $elementsService->getElementById($elementId);
+        // set the current requested site
+        if ($siteHandle !== null) {
+            $site = Craft::$app->getSites()->getSiteByHandle($siteHandle);
+        }
+
+        // query the element based on the current requested site, or the default as fallback
+        $element = $elementsService->getElementById($elementId, null, $site->id ?? null);
+
+        // failsafe if we don't find the specified element
+        if ($element === null) {
+            return $this->asFailure('Failed to find the specified element: ' . $elementId);
+        }
+
         $contentTemplate = $elementsService->getElementById($contentTemplateId);
         $tempDuplicateTemplate = $elementsService->duplicateElement($contentTemplate);
         $element->setFieldValues($tempDuplicateTemplate->getSerializedFieldValues());


### PR DESCRIPTION
Recently I stumbled across an issue with the Craft Content Templates plugin, where upon trying to apply a content template to a new entry, the process would fail with an unknown error and leave duplicated template entries in the Content Templates tab.
Quickly I stumbled upon the issue on [line 243 of the CpController](https://github.com/spicywebau/craft-content-templates/blob/1.0.6/src/controllers/CpController.php#L243): when creating a new entry on any site that isn't the current site (as specified in [getElementById](https://docs.craftcms.com/api/v4/craft-services-elements.html#method-getelementbyid)), the `$element` variable would end up being `null`, thus causing a Null Pointer Exception.

This Pull Request amends the functionality of the apply action by explicitly looking up the 'site' query parameter as it will be properly set by the Craft admin panel when creating a new entry, and adds an extra check to the `$element` variable in case it is still null.

Please feel free to suggest any required changes needed.